### PR TITLE
Make code updates for new Quarkus datasource dev services model

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/jdbc/singlestore/deployment/SinglestoreDevServicesProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jdbc/singlestore/deployment/SinglestoreDevServicesProcessor.java
@@ -1,15 +1,12 @@
 package io.quarkiverse.jdbc.singlestore.deployment;
 
 import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME;
-import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_PASSWORD;
-import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
-import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -18,14 +15,13 @@ import org.testcontainers.utility.DockerImageName;
 
 import io.quarkiverse.jdbc.singlestore.runtime.SinglestoreConstants;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
+import io.quarkus.datasource.deployment.spi.DatasourceStartable;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceContainerConfig;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProviderBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
-import io.quarkus.deployment.dev.devservices.DevServicesConfig;
+import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.devservices.common.ConfigureUtil;
-import io.quarkus.devservices.common.ContainerShutdownCloseable;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.Volumes;
 import io.quarkus.runtime.LaunchMode;
@@ -37,26 +33,26 @@ public class SinglestoreDevServicesProcessor {
     public static final Integer PORT = 3306;
 
     @BuildStep
-    DevServicesDatasourceProviderBuildItem setupSinglestore(
-            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
-            DevServicesConfig globalDevServicesConfig) {
+    DevServicesDatasourceProviderBuildItem setupSinglestore() {
+
         return new DevServicesDatasourceProviderBuildItem(SinglestoreConstants.DB_KIND, new DevServicesDatasourceProvider() {
             @Override
-            public RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
+            public String getFeature() {
+                return "jdbc-singlestore";
+            }
+
+            @Override
+            public DatasourceStartable createDatasourceStartable(Optional<String> username, Optional<String> password,
                     String datasourceName, DevServicesDatasourceContainerConfig containerConfig,
-                    LaunchMode launchMode, Optional<Duration> startupTimeout) {
+                    LaunchMode launchMode, boolean useSharedNetwork, Optional<Duration> startupTimeout) {
 
-                boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(globalDevServicesConfig,
-                        devServicesSharedNetworkBuildItem);
-                QuarkusSinglestoreContainer container = new QuarkusSinglestoreContainer(containerConfig.getImageName(),
-                        containerConfig.getFixedExposedPort(),
-                        useSharedNetwork);
-                startupTimeout.ifPresent(container::withStartupTimeout);
-
-                String effectiveUsername = containerConfig.getUsername().orElse(username.orElse(DEFAULT_DATABASE_USERNAME));
-                String effectivePassword = containerConfig.getPassword().orElse(password.orElse(DEFAULT_DATABASE_PASSWORD));
                 String effectiveDbName = containerConfig.getDbName().orElse(
                         DataSourceUtil.isDefault(datasourceName) ? DEFAULT_DATABASE_NAME : datasourceName);
+
+                QuarkusSinglestoreContainer container = new QuarkusSinglestoreContainer(containerConfig.getImageName(),
+                        containerConfig.getFixedExposedPort(), effectiveDbName,
+                        useSharedNetwork);
+                startupTimeout.ifPresent(container::withStartupTimeout);
 
                 container
                         .withReuse(containerConfig.isReuse());
@@ -69,50 +65,59 @@ public class SinglestoreDevServicesProcessor {
                 containerConfig.getCommand().ifPresent(container::setCommand);
                 containerConfig.getInitScriptPath().ifPresent(container::withInitScripts);
                 container.withDatabaseName("");// bypass for root user
-                container.start();
-                await().until(container::isHealthy);
 
-                try (Connection connection = container.createConnection("");
-                        Statement statement = connection.createStatement()) {
-                    //                    container.execInContainer("singlestore", "-p${ROOT_PASSWORD}" ,"<", "/user.sql");
-                    connection.setAutoCommit(false);
-                    statement.addBatch(String.format("CREATE DATABASE IF NOT EXISTS '%s';", effectiveDbName));//inserting Query in stmt
-                    statement.addBatch(
-                            String.format("CREATE USER %s@'%%' identified by '%s';", effectiveUsername, effectivePassword));
-                    statement.addBatch(String.format("GRANT ALL ON * to '%s';", effectiveUsername));
-                    statement.executeBatch();
-                    LOG.info("User is created.");
-                } catch (SQLException e) {
-                    throw new RuntimeException(e);
-                }
+                return container;
+            }
 
-                // Set the real dbNAme, once user is created.
-                container.withDatabaseName(effectiveDbName);
-                LOG.info("Dev Services for Singlestore started.");
-
-                return new RunningDevServicesDatasource(container.getContainerId(),
-                        container.getEffectiveJdbcUrl(),
-                        container.getReactiveUrl(),
-                        effectiveUsername,
-                        effectivePassword,
-                        new ContainerShutdownCloseable(container, "Singlestore"));
+            @Override
+            public Optional<DevServicesDatasourceProvider.RunningDevServicesDatasource> findRunningComposeDatasource(
+                    LaunchMode launchMode, boolean useSharedNetwork, DevServicesDatasourceContainerConfig containerConfig,
+                    DevServicesComposeProjectBuildItem composeProjectBuildItem) {
+                // No compose support
+                return Optional.empty();
             }
         });
     }
 
-    private static class QuarkusSinglestoreContainer extends SinglestoreContainer {
+    private static class QuarkusSinglestoreContainer extends SinglestoreContainer implements DatasourceStartable {
         private final OptionalInt fixedExposedPort;
         private final boolean useSharedNetwork;
 
         private String hostName = null;
+        private final String effectiveDbName;
 
-        public QuarkusSinglestoreContainer(Optional<String> imageName, OptionalInt fixedExposedPort, boolean useSharedNetwork) {
+        public QuarkusSinglestoreContainer(Optional<String> imageName, OptionalInt fixedExposedPort, String effectiveDbName,
+                boolean useSharedNetwork) {
             super(DockerImageName
                     .parse(imageName.orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("singlestore")))
                     .asCompatibleSubstituteFor(
                             DockerImageName.parse(SinglestoreContainer.FULL_IMAGE_NAME)));
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
+            this.effectiveDbName = effectiveDbName;
+        }
+
+        @Override
+        public void start() {
+            super.start();
+            await().until(this::isHealthy);
+
+            try (Connection connection = this.createConnection("");
+                    Statement statement = connection.createStatement()) {
+                //                    container.execInContainer("singlestore", "-p${ROOT_PASSWORD}" ,"<", "/user.sql");
+                connection.setAutoCommit(false);
+                statement.addBatch(String.format("CREATE DATABASE IF NOT EXISTS '%s';", effectiveDbName));//inserting Query in stmt
+                statement.addBatch(
+                        String.format("CREATE USER %s@'%%' identified by '%s';", getUsername(), getPassword()));
+                statement.addBatch(String.format("GRANT ALL ON * to '%s';", getUsername()));
+                statement.executeBatch();
+                LOG.info("User is created.");
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+
+            // Set the real dbNaAme, once user is created.
+            this.withDatabaseName(effectiveDbName);
         }
 
         @Override
@@ -143,6 +148,7 @@ public class SinglestoreDevServicesProcessor {
 
         // this is meant to be called by Quarkus code and is needed in order to not disrupt testcontainers
         // from being able to determine the status of the container (which it does by trying to acquire a connection)
+        @Override
         public String getEffectiveJdbcUrl() {
             if (useSharedNetwork) {
                 String additionalUrlParams = constructUrlParameters("?", "&");
@@ -152,8 +158,19 @@ public class SinglestoreDevServicesProcessor {
             }
         }
 
+        @Override
         public String getReactiveUrl() {
             return getEffectiveJdbcUrl().replaceFirst("jdbc:singlestore:", "vertx-reactive:singlestore:");
+        }
+
+        @Override
+        public void close() {
+            super.close();
+        }
+
+        @Override
+        public String getConnectionInfo() {
+            return getEffectiveJdbcUrl();
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     </scm>
 
     <properties>
-        <quarkus.version>3.31.2</quarkus.version>
+        <quarkus.version>3.32.0</quarkus.version>
         <singlestore-jdbc.version>1.2.9</singlestore-jdbc.version>
         <assertj-core.version>3.27.7</assertj-core.version>
         <jdbc.version>1.21.4</jdbc.version>


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/pull/52241 introduced a new SPI for datasource dev services, to use the new dev services model, and https://github.com/quarkusio/quarkus/pull/52495 removed support for the old SPI. (Keeping it was just too messy.)

This PR has the changes needed to work with the new SPI. Note that it will only work once the new Quarkus release is available. In the interim, the ecosystem CI for this extension might break. I also couldn't test it locally because an image wasn't available for my ARM machine.